### PR TITLE
Fix missing environment variables for Wi-Fi

### DIFF
--- a/src/MqttMailingService.cpp
+++ b/src/MqttMailingService.cpp
@@ -1,5 +1,6 @@
 #include "MqttMailingService.h"
 #include "event_source.h"
+#include <WiFi.h>
 
 const char* MqttMailingService::TAG = "MQTT Mail";
 esp_mqtt_client_handle_t MqttMailingService::_espMqttClient = nullptr;

--- a/src/MqttMailingService.h
+++ b/src/MqttMailingService.h
@@ -5,7 +5,6 @@
 #include "mqtt_cfg.h"
 #include "mqtt_client.h"
 #include <Arduino.h>
-#include <WiFi.h>
 
 enum MqttMailingServiceState {
     UNINITIALIZED = 0,

--- a/src/mqtt_cfg.h
+++ b/src/mqtt_cfg.h
@@ -20,6 +20,9 @@
 #define MQTT_BROKER_FULL_URI_OVERRIDE "mqtt://mymqttbroker.com:1883"
 #define MQTT_BROKER_CERTIFICATE_OVERRIDE ""
 #define MQTT_USE_SSL_OVERRIDE 0
+
+#define WIFI_SSID_OVERRIDE "Obi-WLAN Kenobi"
+#define WIFI_PW_OVERRIDE "ConnectToTheAP,IWill"
 #endif /* PIO_ADVANCED_SCRIPTING */
 
 #define MQTT_DATAQUEUE_LEN 10


### PR DESCRIPTION
Add Wi-Fi override variables to mqtt_cfg.h. Since they are used in the delegate Wi-Fi interface compilation might fail if they are not defined even if Wi-Fi is not managed by the MQTT library.

Move WiFi.h include from header to cpp file, as it is not used in the interface.