### PR TITLE
Delegate example update

### DIFF
--- a/documentation/api_guide.md
+++ b/documentation/api_guide.md
@@ -18,7 +18,16 @@ Failure to do so globally will likely lead to the instances being destroyed unsa
 terminated, crashing the board.
 
 ### Client start
-You can start the client either with `start()` or with `startWithDelegatedWiFi(ssid, pass)` depending on how you want to handle Wi-Fi connectivity (see dedicated section on that topic).
+You can start the client either with `start()` or with `startWithDelegatedWiFi(ssid, pass, shouldBeBlocking)` depending on how you want to handle Wi-Fi connectivity (see dedicated section on that topic).
+
+#### Blocking or not blocking start ?
+The method `startWithDelegatedWiFi` provides an optional argument `shouldBeBlocking` (false by default) that would make it a blocking call. 
+
+A blocking start would wait for the WiFi and the MQTT client to connect before returning. This limits the error messages logged and ensures no message is lost during startup.  
+However it means that your application will not be runnign during that time... It is up to you to decide if you want a blocking start.
+
+If you choose to have a non-blocking start, the method `isReady()` can help you determine if the connection to the service is ready to forward messages to the MQTT broker.
+
 
 > **Note**  
 Advanced methods are available if you would like to pass your Wi-Fi credentials through macros or *PlatformIO* initialization scripts.

--- a/examples/delegatedWifiUsage/delegatedWifiUsage.ino
+++ b/examples/delegatedWifiUsage/delegatedWifiUsage.ino
@@ -24,25 +24,18 @@ void setup() {
     // Configure the MQTT mailing service
     mqttMailingService.setBrokerURI(broker_uri);
     mailbox = mqttMailingService.getMailbox();
-    // mqttMailingService.setSslCertificate(ssl_cert); // Uncomment for SSL
-    // connection
 
-    mqttMailingService.startWithDelegatedWiFi(ssid, password);
-    while (!WiFi.isConnected()) {
-        // Wait for Wi-Fi connection, since MQTT mailing service
-        // can't establish a connection without Wi-Fi.
-        Serial.println("Waiting for Wi-Fi connection...");
-        sleep(1);
-    }
+    // Uncomment next line for SSL connection
+    // mqttMailingService.setSslCertificate(ssl_cert);
 
-    // Wait until MQTT service connects to broker
-    while (mqttMailingService.getServiceState() !=
-           MqttMailingServiceState::CONNECTED) {
-        Serial.println("MQTT mailing service is connecting...");
-        sleep(1);
-    }
+    Serial.println("MQTT Mailing Service starting and connecting ....");
 
-    Serial.println("setup() complete.");
+    // A blocking start ensure that connection is established before starting
+    // sending messages.
+    bool blockingStart = true;
+    mqttMailingService.startWithDelegatedWiFi(ssid, password, blockingStart);
+
+    Serial.println("MQTT Mailing Service started and connected !");
 }
 
 void loop() {

--- a/examples/selfManagedWifiUsage/selfManagedWifiUsage.ino
+++ b/examples/selfManagedWifiUsage/selfManagedWifiUsage.ino
@@ -36,18 +36,13 @@ void setup() {
     // Connect to Wi-Fi
     WiFi.begin(ssid, password);
     while (!WiFi.isConnected()) {
-        Serial.println("Waiting on the Wi-Fi connection");
+        Serial.println("Waiting on the Wi-Fi connection...");
         sleep(1);
     }
     Serial.println("Connected to Wi-Fi AP !");
 
     // Wait until MQTT service initialized
     mqttMailingService.start();
-    while (mqttMailingService.getServiceState() ==
-           MqttMailingServiceState::UNINITIALIZED) {
-        Serial.println("MQTT mailing service is initializing...");
-        sleep(1);
-    }
 
     Serial.println("setup() complete.");
 }

--- a/src/MqttMailingService.h
+++ b/src/MqttMailingService.h
@@ -34,6 +34,19 @@ class __attribute__((unused)) MqttMailingService {
      * connection. The MqttMailingService will handle connectivity  by itself.
      *
      * @param ssid: The SSID of the WiFi AP
+     * @param pass: the password of the WiFi AP
+     * @param should_be_blocking: Specify if the call should be blocking until
+     * connection is established with broker
+     */
+    __attribute__((unused)) void
+    startWithDelegatedWiFi(const char* ssid, const char* pass,
+                           const bool shouldBeBlocking);
+
+    /**
+     * @brief Starts the MqttMailingService without an established Wi-Fi
+     * connection. The MqttMailingService will handle connectivity  by itself.
+     *
+     * @param ssid: The SSID of the WiFi AP
      *
      * @param pass: the password of the WiFi AP
      *
@@ -115,6 +128,12 @@ class __attribute__((unused)) MqttMailingService {
      */
     __attribute__((unused)) MqttMailingServiceState getServiceState();
 
+    /**
+     * @brief returns whether the service has successfully established
+     * a connection and is ready to forward messages to the broker
+     */
+    __attribute__((unused)) bool isReady();
+
   private:
     static const char* TAG;
     MqttMailingServiceState _state;
@@ -144,10 +163,10 @@ class __attribute__((unused)) MqttMailingService {
     // Running task definition
     [[noreturn]] static void _mailmanTask(void* pMqttMailingService);
     // Event handler
-    static void _espMqttEventHandler(void* handler_args,
-                                     __attribute__((unused))
-                                     esp_event_base_t base,
-                                     int32_t event_id, void* event_data);
+    static void
+    _espMqttEventHandler(void* handler_args,
+                         __attribute__((unused)) esp_event_base_t base,
+                         int32_t event_id, void* event_data);
 };
 
 #endif /* UPT_MQTT_MAILING_SERVICE_H */


### PR DESCRIPTION
This PR provides a new option for a blocking start that simplifies the delegated example. 
The new argument is optional.
If blocking it ensure no message is lost and limits log messages at startup...