### PR TITLE
Prepare for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### 0.2.1
 
 - Updates to make it compile with arduino upt core 0.9
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion UPT MQTT Client
-version=0.1.0
+version=0.2.1
 author=Maximilian Paulsen, Sensirion AG
 maintainer=Sensirion AG <sensirion.com>
 sentence=Send UPT Measurements to an MQTT broker


### PR DESCRIPTION
Update Changelog and library.properties for 0.2.1 release

0.2.0 release was done without updating the library version and therefore failed on platformio.